### PR TITLE
try permissive hold 

### DIFF
--- a/keyball/keyball44/keymaps/default/config.h
+++ b/keyball/keyball44/keymaps/default/config.h
@@ -45,3 +45,4 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #define TAPPING_TERM_PER_KEY
 #define TAPPING_TERM 300
+#define PERMISSIVE_HOLD

--- a/keyball/keyball44/keymaps/default/config.h
+++ b/keyball/keyball44/keymaps/default/config.h
@@ -43,6 +43,5 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define AUTO_MOUSE_DEFAULT_LAYER 3
 #define AUTO_MOUSE_TIME 500
 
-#define PERMISSIVE_HOLD_PER_KEY
 #define TAPPING_TERM_PER_KEY
 #define TAPPING_TERM 300

--- a/keyball/keyball44/keymaps/default/keymap.c
+++ b/keyball/keyball44/keymaps/default/keymap.c
@@ -66,20 +66,6 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
   return true;
 }
 
-// ref: https://docs.qmk.fm/#/tap_hold?id=permissive-hold
-// makes tap and hold keys trigger the hold if another key is pressed
-// before releasing, even if it hasn’t hit the TAPPING_TERM
-bool get_permissive_hold(uint16_t keycode, keyrecord_t *record) {
-    switch (keycode) {
-        case LT(1, CLICK):
-            return true;
-        case LT(2, CLICK):
-            return true;
-        default:
-            return false;
-    }
-}
-
 // ref: https://github.com/qmk/qmk_firmware/blob/master/docs/tap_hold.md#tapping-term
 // permissive hold alone wasn't enough to prevent missed layer key presses
 // (i.e. layer keys weren't triggering when I wanted them to trigger), so make the


### PR DESCRIPTION
when typing fast, for example the letters "se", the "s" is often mistaken for a "control".
maybe this change will fix this problem.