### PR TITLE
decrease tapping term

### DIFF
--- a/keyball/keyball44/keymaps/default/config.h
+++ b/keyball/keyball44/keymaps/default/config.h
@@ -47,5 +47,5 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define AUTO_MOUSE_TIME 500
 
 #define TAPPING_TERM_PER_KEY
-#define TAPPING_TERM 300
+#define TAPPING_TERM 250
 #define PERMISSIVE_HOLD

--- a/keyball/keyball44/keymaps/default/config.h
+++ b/keyball/keyball44/keymaps/default/config.h
@@ -46,5 +46,5 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define AUTO_MOUSE_DEFAULT_LAYER 4
 #define AUTO_MOUSE_TIME 500
 
-#define TAPPING_TERM 250
+#define TAPPING_TERM 200
 #define PERMISSIVE_HOLD

--- a/keyball/keyball44/keymaps/default/config.h
+++ b/keyball/keyball44/keymaps/default/config.h
@@ -46,6 +46,5 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define AUTO_MOUSE_DEFAULT_LAYER 4
 #define AUTO_MOUSE_TIME 500
 
-#define TAPPING_TERM_PER_KEY
 #define TAPPING_TERM 250
 #define PERMISSIVE_HOLD

--- a/keyball/keyball44/keymaps/default/config.h
+++ b/keyball/keyball44/keymaps/default/config.h
@@ -46,5 +46,5 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define AUTO_MOUSE_DEFAULT_LAYER 4
 #define AUTO_MOUSE_TIME 500
 
-#define TAPPING_TERM 200
+#define TAPPING_TERM 150
 #define PERMISSIVE_HOLD

--- a/keyball/keyball44/keymaps/default/keymap.c
+++ b/keyball/keyball44/keymaps/default/keymap.c
@@ -75,21 +75,6 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
   return true;
 }
 
-// ref: https://github.com/qmk/qmk_firmware/blob/master/docs/tap_hold.md#tapping-term
-// permissive hold alone wasn't enough to prevent missed layer key presses
-// (i.e. layer keys weren't triggering when I wanted them to trigger), so make the
-// tapping term for the layer keys shorter.
-uint16_t get_tapping_term(uint16_t keycode, keyrecord_t *record) {
-    switch (keycode) {
-        case LT(1, CLICK):
-            return 80;
-        case LT(2, CLICK):
-            return 80;
-        default:
-            return TAPPING_TERM;
-    }
-}
-
 // ref: https://docs.qmk.fm/#/feature_pointing_device?id=how-to-enable
 void keyboard_post_init_user(void) {
     set_auto_mouse_enable(true);


### PR DESCRIPTION
- `cmd + v`でペーストしようとすると、`jv`という文字列が撃たれてしまう。`cmd`が反応してくれないため、tapping termを低くしてみる
- layerキーをクリックに使っていた時期に設定したtapping term per keyの設定がもう不要なので消した
  - ref: https://github.com/yusukemorita/keyball44_keymap/pull/8