### PR TITLE
increase auto mouse threshold

### DIFF
--- a/keyball/keyball44/keymaps/default/config.h
+++ b/keyball/keyball44/keymaps/default/config.h
@@ -45,6 +45,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define POINTING_DEVICE_AUTO_MOUSE_ENABLE
 #define AUTO_MOUSE_DEFAULT_LAYER 4
 #define AUTO_MOUSE_TIME 500
+// default is 10, increase to prevent accidental mouse layer activations
+#define AUTO_MOUSE_THRESHOLD 20
 
 #define TAPPING_TERM 150
 #define PERMISSIVE_HOLD


### PR DESCRIPTION
- `cmd + ←`でデスクトップを移動しようとする時、よく間違って右クリックが発生する
  - mouse layerが発動してしまっている
  - タイピングの振動のせいでトラックボールセンサーが反応してしまっているのかも？
  - なので、thresholdが小さすぎるのかも。倍にしてみる。