### PR TITLE
try decreasing auto mouse time

### DIFF
--- a/keyball/keyball44/keymaps/default/config.h
+++ b/keyball/keyball44/keymaps/default/config.h
@@ -44,7 +44,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #define POINTING_DEVICE_AUTO_MOUSE_ENABLE
 #define AUTO_MOUSE_DEFAULT_LAYER 4
-#define AUTO_MOUSE_TIME 500
+#define AUTO_MOUSE_TIME 400
 // default is 10, increase to prevent accidental mouse layer activations
 #define AUTO_MOUSE_THRESHOLD 20
 

--- a/keyball/keyball44/keymaps/default/config.h
+++ b/keyball/keyball44/keymaps/default/config.h
@@ -46,7 +46,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define AUTO_MOUSE_DEFAULT_LAYER 4
 #define AUTO_MOUSE_TIME 500
 // default is 10, increase to prevent accidental mouse layer activations
-#define AUTO_MOUSE_THRESHOLD 30
+#define AUTO_MOUSE_THRESHOLD 50
 
 #define TAPPING_TERM 180
 #define PERMISSIVE_HOLD

--- a/keyball/keyball44/keymaps/default/config.h
+++ b/keyball/keyball44/keymaps/default/config.h
@@ -44,7 +44,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #define POINTING_DEVICE_AUTO_MOUSE_ENABLE
 #define AUTO_MOUSE_DEFAULT_LAYER 4
-#define AUTO_MOUSE_TIME 400
+#define AUTO_MOUSE_TIME 500
 // default is 10, increase to prevent accidental mouse layer activations
 #define AUTO_MOUSE_THRESHOLD 20
 

--- a/keyball/keyball44/keymaps/default/config.h
+++ b/keyball/keyball44/keymaps/default/config.h
@@ -46,7 +46,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define AUTO_MOUSE_DEFAULT_LAYER 4
 #define AUTO_MOUSE_TIME 500
 // default is 10, increase to prevent accidental mouse layer activations
-#define AUTO_MOUSE_THRESHOLD 20
+#define AUTO_MOUSE_THRESHOLD 30
 
 #define TAPPING_TERM 180
 #define PERMISSIVE_HOLD


### PR DESCRIPTION
auto mouse layer staying activated and/or activating accidentally prevents usage of `/` and `<` keys
probably the culprit is, accidentally touching the trackball casing when typing?
