### PR TITLE
enable scroll mode when cmd keys are pressed

### DIFF
--- a/keyball/keyball44/keymaps/default/config.h
+++ b/keyball/keyball44/keymaps/default/config.h
@@ -37,7 +37,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 // custom defaults
 #define KEYBALL_CPI_DEFAULT 800
-#define KEYBALL_SCROLL_DIV_DEFAULT 6
+#define KEYBALL_SCROLL_DIV_DEFAULT 7
 
 // enable free direction scroll
 #define KEYBALL_SCROLLSNAP_ENABLE 0

--- a/keyball/keyball44/keymaps/default/keymap.c
+++ b/keyball/keyball44/keymaps/default/keymap.c
@@ -55,6 +55,12 @@ int x_movement_sum = 0;
 int y_movement_sum = 0;
 
 report_mouse_t pointing_device_task_user(report_mouse_t report) {
+  if (get_mods() & MOD_MASK_GUI) {
+    keyball_set_scroll_mode(true); // enable scroll
+  } else {
+    keyball_set_scroll_mode(false); // disable scroll
+  }
+
   if (switch_desktop_with_trackball) {
     x_movement_sum += report.x;
     y_movement_sum += report.y;
@@ -124,15 +130,6 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
         SEND_STRING(SS_DOWN(X_LCMD) SS_DELAY(20) SS_TAP(X_BTN1) SS_DELAY(20) SS_UP(X_LCMD));
       }
       break;
-
-    // enable scroll mode when `CMD` keys are held down
-    case LCMD_T(KC_J):
-    case LCMD_T(KC_F):
-      if (record->event.pressed) {
-        keyball_set_scroll_mode(true); // enable scroll mode
-      } else {
-        keyball_set_scroll_mode(false); // disable scroll mode
-      }
 
     // for switching desktops with trackball
     case MO(1):

--- a/keyball/keyball44/keymaps/default/keymap.c
+++ b/keyball/keyball44/keymaps/default/keymap.c
@@ -108,7 +108,6 @@ report_mouse_t pointing_device_task_user(report_mouse_t report) {
 }
 
 bool process_record_user(uint16_t keycode, keyrecord_t *record) {
-  static uint16_t scroll_timer;
   static uint16_t qk_boot_timer;
 
   switch(keycode) {

--- a/keyball/keyball44/keymaps/default/keymap.c
+++ b/keyball/keyball44/keymaps/default/keymap.c
@@ -55,12 +55,6 @@ int x_movement_sum = 0;
 int y_movement_sum = 0;
 
 report_mouse_t pointing_device_task_user(report_mouse_t report) {
-  if (get_mods() & MOD_MASK_GUI) {
-    keyball_set_scroll_mode(true); // enable scroll
-  } else {
-    keyball_set_scroll_mode(false); // disable scroll
-  }
-
   if (switch_desktop_with_trackball) {
     x_movement_sum += report.x;
     y_movement_sum += report.y;
@@ -108,6 +102,13 @@ report_mouse_t pointing_device_task_user(report_mouse_t report) {
     // prevent cursor movement
     report.x = 0;
     report.y = 0;
+  }
+
+  // enable scroll mode when CMD(GUI) is held down
+  if (get_mods() & MOD_MASK_GUI) {
+    keyball_set_scroll_mode(true);
+  } else {
+    keyball_set_scroll_mode(false);
   }
 
   return report;

--- a/keyball/keyball44/keymaps/default/keymap.c
+++ b/keyball/keyball44/keymaps/default/keymap.c
@@ -126,20 +126,14 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
       }
       break;
 
-    // enable scroll mode when `:` is held down
-    case KC_COLON:
+    // enable scroll mode when `CMD` keys are held down
+    case LCMD_T(KC_J):
+    case LCMD_T(KC_F):
       if (record->event.pressed) {
-        scroll_timer = timer_read();
         keyball_set_scroll_mode(true); // enable scroll mode
       } else {
         keyball_set_scroll_mode(false); // disable scroll mode
-        if (timer_elapsed(scroll_timer) < TAPPING_TERM) {
-          // key was used to input ":"
-          SEND_STRING(":");
-        }
       }
-      // keypress was handled
-      return false;
 
     // for switching desktops with trackball
     case MO(1):


### PR DESCRIPTION
- 小指で`:`押すより人差し指で`j`や`f`の方が押しやすい
- holdで何かするkeyが減った方がややこしさが減るので、すでにhold時の機能がついてる`j`/`f`を使えるといいかも

ついでにスクロールを１段階遅くした