### PR TITLE
try to fix freezing when switching desktops

### DIFF
--- a/keyball/keyball44/keymaps/default/keymap.c
+++ b/keyball/keyball44/keymaps/default/keymap.c
@@ -105,13 +105,6 @@ report_mouse_t pointing_device_task_user(report_mouse_t report) {
     report.y = 0;
   }
 
-  // enable scroll mode when CMD(GUI) is held down
-  if (get_mods() & MOD_MASK_GUI) {
-    keyball_set_scroll_mode(true);
-  } else {
-    keyball_set_scroll_mode(false);
-  }
-
   return report;
 }
 

--- a/keyball/keyball44/keymaps/default/keymap.c
+++ b/keyball/keyball44/keymaps/default/keymap.c
@@ -56,7 +56,7 @@ int y_movement_sum = 0;
 
 report_mouse_t pointing_device_task_user(report_mouse_t report) {
   // trigger desktop operations with left layer key or control
-  if (switch_desktop_with_trackball || (get_mods() & MOD_MASK_CTRL)) {
+  if (switch_desktop_with_trackball) {
     x_movement_sum += report.x;
     y_movement_sum += report.y;
 

--- a/keyball/keyball44/keymaps/default/keymap.c
+++ b/keyball/keyball44/keymaps/default/keymap.c
@@ -19,7 +19,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include QMK_KEYBOARD_H
 
 #include "quantum.h"
-#include "print.h"
 
 // aliases
 
@@ -155,10 +154,10 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
 
     case HOLD_QK_BOOT:
       if (record->event.pressed) {
-        print("start boot timer");
+        SEND_STRING("start boot timer");
         qk_boot_timer = timer_read();
       } else {
-        print("  measure boot timer");
+        SEND_STRING("  measure boot timer");
         // trigger boot mode if held down for 2 seconds
         if (timer_elapsed(qk_boot_timer) > 2000) {
           bootloader_jump();

--- a/keyball/keyball44/keymaps/default/keymap.c
+++ b/keyball/keyball44/keymaps/default/keymap.c
@@ -63,11 +63,13 @@ report_mouse_t pointing_device_task_user(report_mouse_t report) {
     // when sum has reached threshold, trigger switch
     if (x_movement_sum > switch_desktop_x_threshold) {
       // move to left desktop
-      SEND_STRING(SS_DOWN(X_LCTL) SS_DELAY(20) SS_TAP(X_LEFT) SS_DELAY(20) SS_UP(X_LCTL));
+      // SEND_STRING(SS_DOWN(X_LCTL) SS_DELAY(20) SS_TAP(X_LEFT) SS_DELAY(20) SS_UP(X_LCTL));
+      SEND_STRING("1,");
       x_movement_sum -= switch_desktop_x_threshold;
     } else if (x_movement_sum < -switch_desktop_x_threshold) {
       // move to right desktop
-      SEND_STRING(SS_DOWN(X_LCTL) SS_DELAY(20) SS_TAP(X_RIGHT) SS_DELAY(20) SS_UP(X_LCTL));
+      // SEND_STRING(SS_DOWN(X_LCTL) SS_DELAY(20) SS_TAP(X_RIGHT) SS_DELAY(20) SS_UP(X_LCTL));
+      SEND_STRING("2,");
       x_movement_sum += switch_desktop_x_threshold;
     }
 

--- a/keyball/keyball44/keymaps/default/keymap.c
+++ b/keyball/keyball44/keymaps/default/keymap.c
@@ -56,7 +56,7 @@ int y_movement_sum = 0;
 
 report_mouse_t pointing_device_task_user(report_mouse_t report) {
   // trigger desktop operations with left layer key or control
-  if (switch_desktop_with_trackball) {
+  if (switch_desktop_with_trackball || (get_mods() & MOD_MASK_CTRL)) {
     x_movement_sum += report.x;
     y_movement_sum += report.y;
 

--- a/keyball/keyball44/keymaps/default/keymap.c
+++ b/keyball/keyball44/keymaps/default/keymap.c
@@ -105,6 +105,13 @@ report_mouse_t pointing_device_task_user(report_mouse_t report) {
     report.y = 0;
   }
 
+  // enable scroll mode when CMD(GUI) is held down
+  if (get_mods() & MOD_MASK_GUI) {
+    keyball_set_scroll_mode(true);
+  } else {
+    keyball_set_scroll_mode(false);
+  }
+
   return report;
 }
 

--- a/keyball/keyball44/keymaps/default/keymap.c
+++ b/keyball/keyball44/keymaps/default/keymap.c
@@ -141,6 +141,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
         switch_desktop_with_trackball = false;
         x_movement_sum = 0;
       }
+      break;
 
     // for switching tabs with trackball
     case KC_M:
@@ -151,13 +152,12 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
         x_movement_sum = 0;
         y_movement_sum = 0;
       }
+      break;
 
     case HOLD_QK_BOOT:
       if (record->event.pressed) {
-        SEND_STRING("start boot timer");
         qk_boot_timer = timer_read();
       } else {
-        SEND_STRING("  measure boot timer");
         // trigger boot mode if held down for 2 seconds
         if (timer_elapsed(qk_boot_timer) > 2000) {
           bootloader_jump();
@@ -183,7 +183,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     XXXXXXX   , _______   , _______   , L_TAB     , R_TAB     , _______   ,                          KC_0     , KC_1     , KC_2     , KC_3     , _______  , XXXXXXX,
     XXXXXXX   , _______   , KC_LCBR   , KC_DEL    , KC_BSPC   , KC_RCBR   ,                          KC_MINUS , KC_4     , KC_5     , KC_6     , _______  , XXXXXXX,
     XXXXXXX   , _______   , _______   , _______   , _______   , _______   ,                          KC_EQUAL , KC_7     , KC_8     , KC_9     , _______  , XXXXXXX,
-    XXXXXXX   , _______   ,             _______   , _______   , HOLD_QK_BOOT,                     ESC_AND_ENG , MO(3)    ,        _______  , _______  , _______
+    XXXXXXX   , _______   ,             _______   , _______   , HOLD_QK_BOOT,                     ESC_AND_ENG , MO(3)    ,            _______  , _______  , _______
   ),
 
   // symbols

--- a/keyball/keyball44/keymaps/default/keymap.c
+++ b/keyball/keyball44/keymaps/default/keymap.c
@@ -63,19 +63,17 @@ report_mouse_t pointing_device_task_user(report_mouse_t report) {
     // when sum has reached threshold, trigger switch
     if (x_movement_sum > switch_desktop_x_threshold) {
       // move to left desktop
-      // SEND_STRING(SS_DOWN(X_LCTL) SS_DELAY(20) SS_TAP(X_LEFT) SS_DELAY(20) SS_UP(X_LCTL));
-      SEND_STRING("1,");
+      SEND_STRING(SS_DOWN(X_LCTL) SS_DELAY(1) SS_TAP(X_LEFT) SS_DELAY(1) SS_UP(X_LCTL));
       x_movement_sum -= switch_desktop_x_threshold;
     } else if (x_movement_sum < -switch_desktop_x_threshold) {
       // move to right desktop
-      // SEND_STRING(SS_DOWN(X_LCTL) SS_DELAY(20) SS_TAP(X_RIGHT) SS_DELAY(20) SS_UP(X_LCTL));
-      SEND_STRING("2,");
+      SEND_STRING(SS_DOWN(X_LCTL) SS_DELAY(1) SS_TAP(X_RIGHT) SS_DELAY(1) SS_UP(X_LCTL));
       x_movement_sum += switch_desktop_x_threshold;
     }
 
     if (y_movement_sum < -switch_desktop_y_threshold) {
       // mission control
-      SEND_STRING(SS_DOWN(X_LCTL) SS_DELAY(20) SS_TAP(X_UP) SS_DELAY(20) SS_UP(X_LCTL));
+      SEND_STRING(SS_DOWN(X_LCTL) SS_DELAY(1) SS_TAP(X_UP) SS_DELAY(1) SS_UP(X_LCTL));
       y_movement_sum = 0; // set to zero to prevent triggering multiple times
     } else if (y_movement_sum > switch_desktop_y_threshold) {
       // show desktop

--- a/keyball/keyball44/keymaps/default/keymap.c
+++ b/keyball/keyball44/keymaps/default/keymap.c
@@ -19,6 +19,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include QMK_KEYBOARD_H
 
 #include "quantum.h"
+#include "print.h"
 
 // aliases
 
@@ -59,6 +60,8 @@ report_mouse_t pointing_device_task_user(report_mouse_t report) {
   if (switch_desktop_with_trackball || (get_mods() & MOD_MASK_CTRL)) {
     x_movement_sum += report.x;
     y_movement_sum += report.y;
+
+    uprintf("sums (x, y) = (%s, %s)", x_movement_sum, y_movement_sum);
 
     // when sum has reached threshold, trigger switch
     if (x_movement_sum > switch_desktop_x_threshold) {
@@ -116,7 +119,7 @@ report_mouse_t pointing_device_task_user(report_mouse_t report) {
 }
 
 bool process_record_user(uint16_t keycode, keyrecord_t *record) {
-  static uint16_t qk_boot_timer;
+  // static uint16_t qk_boot_timer;
 
   switch(keycode) {
     case ESC_AND_ENG:
@@ -152,15 +155,15 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
         y_movement_sum = 0;
       }
 
-    case HOLD_QK_BOOT:
-      if (record->event.pressed) {
-        qk_boot_timer = timer_read();
-      } else {
-        // trigger boot mode if held down for 2 seconds
-        if (timer_elapsed(qk_boot_timer) > 2000) {
-          bootloader_jump();
-        }
-      }
+    // case HOLD_QK_BOOT:
+    //   if (record->event.pressed) {
+    //     qk_boot_timer = timer_read();
+    //   } else {
+    //     // trigger boot mode if held down for 2 seconds
+    //     if (timer_elapsed(qk_boot_timer) > 2000) {
+    //       bootloader_jump();
+    //     }
+    //   }
   }
 
   return true;

--- a/keyball/keyball44/keymaps/default/keymap.c
+++ b/keyball/keyball44/keymaps/default/keymap.c
@@ -61,8 +61,6 @@ report_mouse_t pointing_device_task_user(report_mouse_t report) {
     x_movement_sum += report.x;
     y_movement_sum += report.y;
 
-    uprintf("sums (x, y) = (%s, %s)", x_movement_sum, y_movement_sum);
-
     // when sum has reached threshold, trigger switch
     if (x_movement_sum > switch_desktop_x_threshold) {
       // move to left desktop
@@ -119,7 +117,7 @@ report_mouse_t pointing_device_task_user(report_mouse_t report) {
 }
 
 bool process_record_user(uint16_t keycode, keyrecord_t *record) {
-  // static uint16_t qk_boot_timer;
+  static uint16_t qk_boot_timer;
 
   switch(keycode) {
     case ESC_AND_ENG:
@@ -155,15 +153,17 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
         y_movement_sum = 0;
       }
 
-    // case HOLD_QK_BOOT:
-    //   if (record->event.pressed) {
-    //     qk_boot_timer = timer_read();
-    //   } else {
-    //     // trigger boot mode if held down for 2 seconds
-    //     if (timer_elapsed(qk_boot_timer) > 2000) {
-    //       bootloader_jump();
-    //     }
-    //   }
+    case HOLD_QK_BOOT:
+      if (record->event.pressed) {
+        print("start boot timer");
+        qk_boot_timer = timer_read();
+      } else {
+        print("  measure boot timer");
+        // trigger boot mode if held down for 2 seconds
+        if (timer_elapsed(qk_boot_timer) > 2000) {
+          bootloader_jump();
+        }
+      }
   }
 
   return true;

--- a/keyball/keyball44/keymaps/default/keymap.c
+++ b/keyball/keyball44/keymaps/default/keymap.c
@@ -84,6 +84,7 @@ report_mouse_t pointing_device_task_user(report_mouse_t report) {
     // prevent cursor movement
     report.x = 0;
     report.y = 0;
+    return report;
   }
 
   if (switch_tabs_with_trackball) {
@@ -103,6 +104,7 @@ report_mouse_t pointing_device_task_user(report_mouse_t report) {
     // prevent cursor movement
     report.x = 0;
     report.y = 0;
+    return report;
   }
 
   // enable scroll mode when CMD(GUI) is held down

--- a/keyball/keyball44/keymaps/default/keymap.c
+++ b/keyball/keyball44/keymaps/default/keymap.c
@@ -84,7 +84,6 @@ report_mouse_t pointing_device_task_user(report_mouse_t report) {
     // prevent cursor movement
     report.x = 0;
     report.y = 0;
-    return report;
   }
 
   if (switch_tabs_with_trackball) {
@@ -104,7 +103,6 @@ report_mouse_t pointing_device_task_user(report_mouse_t report) {
     // prevent cursor movement
     report.x = 0;
     report.y = 0;
-    return report;
   }
 
   // enable scroll mode when CMD(GUI) is held down

--- a/keyball/keyball44/keymaps/default/rules.mk
+++ b/keyball/keyball44/keymaps/default/rules.mk
@@ -1,1 +1,2 @@
 OLED_ENABLE = yes
+CONSOLE_ENABLE=yes

--- a/keyball/keyball44/keymaps/default/rules.mk
+++ b/keyball/keyball44/keymaps/default/rules.mk
@@ -1,2 +1,1 @@
 OLED_ENABLE = yes
-CONSOLE_ENABLE=yes


### PR DESCRIPTION
左手レイヤーキーを押してデスクトップ移動をしていると、スクロール量が多いとキーボードがフリーズする。
数秒経つと元に戻る。


~↓で追加したコードがかなりの数実行されるから、処理が重いのかも？~
https://github.com/yusukemorita/keyball44_keymap/pull/38/files

~と思ったが、レイヤーキー押さない、普通のトラックボール移動だと、発生しないので謎い~

clangの`switch`文では、`break`がないとそれ以降の全てのcaseの処理が走ってしまう、のが原因だった。